### PR TITLE
Include component specs in the bundle

### DIFF
--- a/example/graphs/InvertAsync.fbp
+++ b/example/graphs/InvertAsync.fbp
@@ -1,3 +1,3 @@
 INPORT=Async.IN:IN
 OUTPORT=Invert.OUT:OUT
-Async(core/RepeatAsync) OUT -> IN Invert(component-loader-example/Invert)
+Async(core/RepeatDelayed) OUT -> IN Invert(component-loader-example/Invert)

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -83,6 +83,7 @@ exports.getSource = function (sources, loader, name, callback) {
   } else if (sources[name]) {
     componentData.code = sources[name].source;
     componentData.language = sources[name].language;
+    componentData.tests = sources[name].tests;
     return callback(null, componentData);
   } else if (typeof component === 'function') {
     componentData.code = component.toString();

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -1,5 +1,8 @@
 const path = require('path');
 const fs = require('fs');
+const { promisify } = require('util');
+
+const readFile = promisify(fs.readFile);
 
 function modulesToData(modules, options) {
   const data = {
@@ -26,10 +29,9 @@ function modulesToData(modules, options) {
     module.components.forEach((component) => {
       const componentPath = path.resolve(options.baseDir, component.path);
       data.components.push({
+        ...component,
         module: module.name,
-        name: component.name,
         path: componentPath,
-        elementary: component.elementary,
       });
     });
   });
@@ -41,30 +43,31 @@ function modulesToData(modules, options) {
 
   const sourcePromises = data.components
     .filter((component) => component.elementary)
-    .map((component) => {
-      const p = new Promise((resolve, reject) => {
-        fs.readFile(component.path, 'utf-8', (err, source) => {
-          if (err) {
-            reject(err);
-            return;
-          }
-          let language = 'javascript';
-          if (path.extname(component.path) === '.coffee') {
-            language = 'coffeescript';
-          }
-          if (path.extname(component.path) === '.ts') {
-            language = 'typescript';
-          }
-          const fullName = component.module ? `${component.module}/${component.name}` : component.name;
-          data.sources[fullName] = {
-            language,
-            source,
-          };
-          resolve();
-        });
-      });
-      return p;
-    });
+    .map((component) => readFile(component.path, 'utf-8')
+      .then((source) => {
+        let language = 'javascript';
+        if (path.extname(component.path) === '.coffee') {
+          language = 'coffeescript';
+        }
+        if (path.extname(component.path) === '.ts') {
+          language = 'typescript';
+        }
+        const fullName = component.module ? `${component.module}/${component.name}` : component.name;
+        data.sources[fullName] = {
+          language,
+          source,
+        };
+        console.log(component);
+        if (!component.tests) {
+          return Promise.resolve();
+        }
+        return readFile(component.tests, 'utf-8')
+          .then((specs) => {
+            data.sources[fullName].tests = specs;
+          }, () => {
+          });
+      }));
+
   return Promise.all(sourcePromises)
     .then(() => data);
 }

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -52,6 +52,9 @@ function modulesToData(modules, options) {
           if (path.extname(component.path) === '.coffee') {
             language = 'coffeescript';
           }
+          if (path.extname(component.path) === '.ts') {
+            language = 'typescript';
+          }
           const fullName = component.module ? `${component.module}/${component.name}` : component.name;
           data.sources[fullName] = {
             language,

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "webpack-cli": "^3.0.0"
   },
   "dependencies": {
-    "fbp-manifest": "^0.2.0",
+    "fbp-manifest": "^0.2.6",
     "loader-utils": "^2.0.0"
   }
 }

--- a/spec/webpack.js
+++ b/spec/webpack.js
@@ -31,7 +31,15 @@ describe('Webpack build of example project', () => {
   it('should be possible to build', (done) => {
     exec('npm run build', {
       cwd: examplePath,
-    }, done);
+    }, (err, stdout, stderr) => {
+      if (err) {
+        console.error(stderr);
+        done(err);
+        return;
+      }
+      console.log(stdout);
+      done();
+    });
   }).timeout(60000);
   it('should produce a loadable module', () => {
     bundle = require('../example/example.bundle.js');

--- a/spec/webpack.js
+++ b/spec/webpack.js
@@ -52,32 +52,44 @@ describe('Webpack build of example project', () => {
       done();
     });
   });
-  it('should have core/RepeatAsync available', (done) => {
+  it('should have core/RepeatDelayed available', (done) => {
     const loader = new bundle.ComponentLoader();
-    loader.load('core/RepeatAsync', (err, inst) => {
+    loader.load('core/RepeatDelayed', (err, inst) => {
       if (err) return done(err);
       expect(inst).to.be.an('object');
       done();
     });
   });
-  it('should not have core/Repeat available', (done) => {
-    const loader = new bundle.ComponentLoader();
-    loader.load('core/Repeat', (err, inst) => {
-      expect(err).to.be.an('error');
-      done();
-    });
-  });
-  it('should return original sources with getSource', (done) => {
-    const sourcePath = path.resolve(__dirname, '../node_modules/noflo-core/components/RepeatAsync.js');
+  it('should return original core/RepeatDelayed sources with getSource', (done) => {
+    const sourcePath = path.resolve(__dirname, '../node_modules/noflo-core/components/RepeatDelayed.js');
     const loader = new bundle.ComponentLoader();
     fs.readFile(sourcePath, 'utf-8', (err, original) => {
       if (err) return done(err);
-      loader.getSource('core/RepeatAsync', (err, loaded) => {
+      loader.getSource('core/RepeatDelayed', (err, loaded) => {
         if (err) return done(err);
         expect(loaded.language).to.equal('javascript');
         expect(loaded.code).to.equal(original);
         done();
       });
+    });
+  });
+  it('should return original core/RepeatDelayed specs with getSource', (done) => {
+    const sourcePath = path.resolve(__dirname, '../node_modules/noflo-core/spec/RepeatDelayed.yaml');
+    const loader = new bundle.ComponentLoader();
+    fs.readFile(sourcePath, 'utf-8', (err, original) => {
+      if (err) return done(err);
+      loader.getSource('core/RepeatDelayed', (err, loaded) => {
+        if (err) return done(err);
+        expect(loaded.tests).to.equal(original);
+        done();
+      });
+    });
+  });
+  it('should not have core/RepeatAsync available', (done) => {
+    const loader = new bundle.ComponentLoader();
+    loader.load('core/RepeatAsync', (err, inst) => {
+      expect(err).to.be.an('error');
+      done();
     });
   });
   describe('setting sources', () => {


### PR DESCRIPTION
When `debug` option is enabled, component sources sent by runtime will also contain the component specs when available.